### PR TITLE
Force Alpine 3.6 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine
+FROM lsiobase/alpine:3.6
 
 MAINTAINER romancin
 


### PR DESCRIPTION
With Alpine 3.7, xmlrpc doesn't compile.