### PR TITLE
Updated curl to 7.64.1 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL build_version="Romancin version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 ARG MEDIAINF_VER="18.12"
 ARG RTORRENT_VER="v0.9.7"
 ARG LIBTORRENT_VER="v0.13.7"
-ARG CURL_VER="7.64.0"
+ARG CURL_VER="7.64.1"
 
 # set env
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig


### PR DESCRIPTION
curl 7.64.0 version has an issue that causes very high CPU usage in rtorrent. This version should fix this behaviour.