### PR TITLE
Bugfix rutorrent mobile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,7 @@ git clone https://github.com/Gyran/rutorrent-pausewebui pausewebui && \
 git clone https://github.com/Gyran/rutorrent-ratiocolor ratiocolor && \
 sed -i 's/changeWhat = "cell-background";/changeWhat = "font";/g' /usr/share/webapps/rutorrent/plugins/ratiocolor/init.js && \
 git clone https://github.com/Gyran/rutorrent-instantsearch instantsearch && \
-git clone https://github.com/xombiemp/rutorrentMobile && \
+git clone https://github.com/xombiemp/rutorrentMobile mobile && \
 git clone https://github.com/dioltas/AddZip && \
 git clone https://github.com/Micdu70/geoip2-rutorrent geoip2 && \
 rm -rf geoip && \

--- a/root/defaults/rutorrent-conf/plugins.ini
+++ b/root/defaults/rutorrent-conf/plugins.ini
@@ -26,7 +26,7 @@ canChangeStatusBar = yes
 canChangeCategory = yes
 
 [ipad]
-enabled = disabled
+enabled = no
 canChangeToolbar = yes
 canChangeMenu = yes
 canChangeOptions = yes

--- a/root/defaults/rutorrent-conf/plugins.ini
+++ b/root/defaults/rutorrent-conf/plugins.ini
@@ -1,0 +1,36 @@
+;; Plugins' permissions.
+;; If flag is not found in plugin section, corresponding flag from "default" section is used.
+;; If flag is not found in "default" section, it is assumed to be "yes".
+;;
+;; For setting individual plugin permissions you must write something like that:
+;;
+;; [ratio]
+;; enabled = yes                        ;; also may be "user-defined", in this case user can control plugin's state from UI
+;; canChangeToolbar = yes
+;; canChangeMenu = yes
+;; canChangeOptions = no
+;; canChangeTabs = yes
+;; canChangeColumns = yes
+;; canChangeStatusBar = yes
+;; canChangeCategory = yes
+;; canBeShutdowned = yes
+
+[default]
+enabled = user-defined
+canChangeToolbar = yes
+canChangeMenu = yes
+canChangeOptions = yes
+canChangeTabs = yes
+canChangeColumns = yes
+canChangeStatusBar = yes
+canChangeCategory = yes
+
+[ipad]
+enabled = disabled
+canChangeToolbar = yes
+canChangeMenu = yes
+canChangeOptions = yes
+canChangeTabs = yes
+canChangeColumns = yes
+canChangeStatusBar = yes
+canChangeCategory = yes


### PR DESCRIPTION
This merge request disables the ipad plugin and changes the name of the rutorrentmobile plugin folder to mobile, as described in the readme of the plugin. Tested by building with the following args:

      args:
        - BASEIMAGE_VERSION=3.11
        - RTORRENT_VER=v0.9.8
        - LIBTORRENT_VER=v0.13.8

fixes: #132